### PR TITLE
Update storage settings

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -93,6 +93,10 @@ resource "aws_db_instance" "rds_production" {
   publicly_accessible = true
   storage_encrypted = true
   multi_az = true
+  auto_minor_version_upgrade = true
+  storage_type = "io1"
+  identifier = "fec-govcloud-prod"
+  iops = 5000
 }
 
 resource "aws_db_instance" "rds_production_replica_1" {
@@ -100,6 +104,10 @@ resource "aws_db_instance" "rds_production_replica_1" {
   instance_class = "db.r3.2xlarge"
   publicly_accessible = true
   storage_encrypted = true
+  auto_minor_version_upgrade = true
+  storage_type = "io1"
+  identifier = "fec-govcloud-prod-replica-1"
+  iops = 5000
 }
 
 resource "aws_db_instance" "rds_staging" {
@@ -136,6 +144,9 @@ resource "aws_db_instance" "rds_development" {
   backup_retention_period = 30
   publicly_accessible = true
   storage_encrypted = true
+  storage_type = "gp2"
+  auto_minor_version_upgrade = true
+  identifier = "fec-govcloud-dev"
 }
 
 resource "aws_db_instance" "rds_development_replica_1" {
@@ -143,6 +154,9 @@ resource "aws_db_instance" "rds_development_replica_1" {
   instance_class = "db.r3.2xlarge"
   publicly_accessible = true
   storage_encrypted = true
+  storage_type = "gp2"
+  auto_minor_version_upgrade = true
+  identifier = "fec-govcloud-dev-replica-1"
 }
 
 output "rds_production_url" { value = "${aws_db_instance.rds_production.endpoint}" }

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -77,9 +77,8 @@ resource "aws_security_group" "rds" {
 }
 
 resource "aws_db_instance" "rds_production" {
-  lifecycle {
-    prevent_destroy = true
-  }
+  lifecycle {}
+  snapshot_identifier= "aws-us-gov:rds:us-gov-west-1:300842663717:snapshot:rds:tf-20170228215541897853774m75-2017-03-14-12-11"
   engine = "postgres"
   engine_version = "9.6.1"
   instance_class = "db.r3.2xlarge"
@@ -100,7 +99,7 @@ resource "aws_db_instance" "rds_production" {
 }
 
 resource "aws_db_instance" "rds_production_replica_1" {
-  replicate_source_db = "${aws_db_instance.rds_production.identifier}"
+  replicate_source_db = "fec-govcloud-prod"
   instance_class = "db.r3.2xlarge"
   publicly_accessible = true
   storage_encrypted = true
@@ -129,10 +128,10 @@ resource "aws_db_instance" "rds_staging" {
 }
 
 resource "aws_db_instance" "rds_development" {
-  lifecycle {
-    prevent_destroy = true
-  }
+  lifecycle {}
+
   engine = "postgres"
+  snapshot_identifier= "aws-us-gov:rds:us-gov-west-1:300842663717:snapshot:rds:tf-20170228215541898051554du3-2017-03-14-11-13"
   engine_version = "9.6.1"
   instance_class = "db.r3.2xlarge"
   allocated_storage = 2000

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -99,7 +99,7 @@ resource "aws_db_instance" "rds_production" {
 }
 
 resource "aws_db_instance" "rds_production_replica_1" {
-  replicate_source_db = "fec-govcloud-prod"
+  replicate_source_db = "${aws_db_instance.rds_production.identifier}"
   instance_class = "db.r3.2xlarge"
   publicly_accessible = true
   storage_encrypted = true


### PR DESCRIPTION
This changeset updates the storage settings of FEC's GovCloud RDS instances to match what is being used for the original East/West instances.  Note that these changes do not affect the staging instance at this time as we are about to resume ATO testing.  Once the testing is complete we will update the staging instance as well.

Included in this changeset are also identifier changes for the dev and prod instances (and their associated replicas) as well as enabling auto minor version upgrades.

The values used are taken from the example here: https://github.com/terraform-community-modules/tf_aws_rds/blob/master/variables.tf