### PR TITLE
Updated maintenance window and apply immediately

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -98,7 +98,7 @@ resource "aws_db_instance" "rds_production" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod"
   iops = 12000
-  maintenance_window = "Sat:06:00-Sat:8:00"
+  maintenance_window = "Sat:06:00-Sat:08:00"
   apply_immediately = true
 }
 
@@ -111,7 +111,7 @@ resource "aws_db_instance" "rds_production_replica_1" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-1"
   iops = 12000
-  maintenance_window = "Sat:06:00-Sat:8:00"
+  maintenance_window = "Sat:06:00-Sat:08:00"
   apply_immediately = true
 }
 
@@ -124,7 +124,7 @@ resource "aws_db_instance" "rds_production_replica_2" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-2"
   iops = 12000
-  maintenance_window = "Sat:06:00-Sat:8:00"
+  maintenance_window = "Sat:06:00-Sat:08:00"
   apply_immediately = true
 }
 
@@ -148,7 +148,7 @@ resource "aws_db_instance" "rds_staging" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-stage"
-  maintenance_window = "Sat:06:00-Sat:8:00"
+  maintenance_window = "Sat:06:00-Sat:08:00"
   apply_immediately = true
 }
 
@@ -172,7 +172,7 @@ resource "aws_db_instance" "rds_development" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-dev"
-  maintenance_window = "Sat:06:00-Sat:8:00"
+  maintenance_window = "Sat:06:00-Sat:08:00"
   apply_immediately = true
 }
 
@@ -184,7 +184,7 @@ resource "aws_db_instance" "rds_development_replica_1" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-dev-replica-1"
-  maintenance_window = "Sat:06:00-Sat:8:00"
+  maintenance_window = "Sat:06:00-Sat:08:00"
   apply_immediately = true
 }
 

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -98,7 +98,7 @@ resource "aws_db_instance" "rds_production" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod"
   iops = 12000
-  maintenance_window = "Tue:06:00-Tue:8:00"
+  maintenance_window = "Sat:06:00-Sat:8:00"
   apply_immediately = true
 }
 
@@ -111,7 +111,7 @@ resource "aws_db_instance" "rds_production_replica_1" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-1"
   iops = 12000
-  maintenance_window = "Tue:06:00-Tue:8:00"
+  maintenance_window = "Sat:06:00-Sat:8:00"
   apply_immediately = true
 }
 
@@ -124,7 +124,7 @@ resource "aws_db_instance" "rds_production_replica_2" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-2"
   iops = 12000
-  maintenance_window = "Tue:06:00-Tue:8:00"
+  maintenance_window = "Sat:06:00-Sat:8:00"
   apply_immediately = true
 }
 
@@ -148,7 +148,7 @@ resource "aws_db_instance" "rds_staging" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-stage"
-  maintenance_window = "Tue:06:00-Tue:8:00"
+  maintenance_window = "Sat:06:00-Sat:8:00"
   apply_immediately = true
 }
 
@@ -172,7 +172,7 @@ resource "aws_db_instance" "rds_development" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-dev"
-  maintenance_window = "Tue:06:00-Tue:8:00"
+  maintenance_window = "Sat:06:00-Sat:8:00"
   apply_immediately = true
 }
 
@@ -184,7 +184,7 @@ resource "aws_db_instance" "rds_development_replica_1" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-dev-replica-1"
-  maintenance_window = "Tue:06:00-Tue:8:00"
+  maintenance_window = "Sat:06:00-Sat:8:00"
   apply_immediately = true
 }
 

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -98,6 +98,8 @@ resource "aws_db_instance" "rds_production" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod"
   iops = 12000
+  maintenance_window = "Tue:06:00-Tue:8:00"
+  apply_immediately = true
 }
 
 resource "aws_db_instance" "rds_production_replica_1" {
@@ -109,6 +111,8 @@ resource "aws_db_instance" "rds_production_replica_1" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-1"
   iops = 12000
+  maintenance_window = "Tue:06:00-Tue:8:00"
+  apply_immediately = true
 }
 
 resource "aws_db_instance" "rds_production_replica_2" {
@@ -120,6 +124,8 @@ resource "aws_db_instance" "rds_production_replica_2" {
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-2"
   iops = 12000
+  maintenance_window = "Tue:06:00-Tue:8:00"
+  apply_immediately = true
 }
 
 resource "aws_db_instance" "rds_staging" {
@@ -142,6 +148,8 @@ resource "aws_db_instance" "rds_staging" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-stage"
+  maintenance_window = "Tue:06:00-Tue:8:00"
+  apply_immediately = true
 }
 
 resource "aws_db_instance" "rds_development" {
@@ -164,6 +172,8 @@ resource "aws_db_instance" "rds_development" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-dev"
+  maintenance_window = "Tue:06:00-Tue:8:00"
+  apply_immediately = true
 }
 
 resource "aws_db_instance" "rds_development_replica_1" {
@@ -174,6 +184,8 @@ resource "aws_db_instance" "rds_development_replica_1" {
   storage_type = "gp2"
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-dev-replica-1"
+  maintenance_window = "Tue:06:00-Tue:8:00"
+  apply_immediately = true
 }
 
 output "rds_production_url" { value = "${aws_db_instance.rds_production.endpoint}" }


### PR DESCRIPTION
We recently sent some configuration updates to AWS but did not include the apply immediately parameter.  Furthermore, the maintenance window is not at an appropriate time for us.  This changeset adjusts the maintenance window across all instances and sets the apply immediately parameter to make all of our changes now.

The maintenance time windows are in UTC time.