### PR TITLE
Add custom parameter group to support config changes

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -130,7 +130,6 @@ resource "aws_db_instance" "rds_production" {
   identifier = "fec-govcloud-prod"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
-  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -144,7 +143,6 @@ resource "aws_db_instance" "rds_production_replica_1" {
   identifier = "fec-govcloud-prod-replica-1"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
-  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -158,7 +156,6 @@ resource "aws_db_instance" "rds_production_replica_2" {
   identifier = "fec-govcloud-prod-replica-2"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
-  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -76,6 +76,17 @@ resource "aws_security_group" "rds" {
   }
 }
 
+resource "aws_db_parameter_group" "fec_default" {
+    name = "fec_default"
+    family = "postgres9.6"
+    description = "Custom parameters to support FEC"
+
+    parameter {
+        name = "max_parallel_workers_per_gather"
+        value = 4
+    }
+}
+
 resource "aws_db_instance" "rds_production" {
   lifecycle {
     prevent_destroy = true
@@ -99,6 +110,7 @@ resource "aws_db_instance" "rds_production" {
   identifier = "fec-govcloud-prod"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -112,6 +124,7 @@ resource "aws_db_instance" "rds_production_replica_1" {
   identifier = "fec-govcloud-prod-replica-1"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -125,6 +138,7 @@ resource "aws_db_instance" "rds_production_replica_2" {
   identifier = "fec-govcloud-prod-replica-2"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -149,6 +163,7 @@ resource "aws_db_instance" "rds_staging" {
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-stage"
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -173,6 +188,7 @@ resource "aws_db_instance" "rds_development" {
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-dev"
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -185,6 +201,7 @@ resource "aws_db_instance" "rds_development_replica_1" {
   auto_minor_version_upgrade = true
   identifier = "fec-govcloud-dev-replica-1"
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -83,7 +83,27 @@ resource "aws_db_parameter_group" "fec_default" {
 
     parameter {
         name = "max_parallel_workers_per_gather"
-        value = 4
+        value = "4"
+    }
+
+    parameter {
+        name  = "log_connections"
+        value = "1"
+    }
+
+    parameter {
+        name  = "log_disconnections"
+        value = "1"
+    }
+
+    parameter {
+        name  = "log_hostname"
+        value = "0"
+    }
+
+    parameter {
+        name  = "log_statement"
+        value = "ddl"
     }
 }
 


### PR DESCRIPTION
Implements https://github.com/18F/openFEC/issues/2457

This changeset adds support for creating a new custom parameter group in order to configure our PostgreSQL settings.  Specifically, we would like to enable the `max_parallel_workers_per_gather` setting in order to take advantage of parallel queries, but there might be other things we want to tweak or modify in the future.