### PR TITLE
Swap parameter group in production

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -130,6 +130,7 @@ resource "aws_db_instance" "rds_production" {
   identifier = "fec-govcloud-prod"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -143,6 +144,7 @@ resource "aws_db_instance" "rds_production_replica_1" {
   identifier = "fec-govcloud-prod-replica-1"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 
@@ -156,6 +158,7 @@ resource "aws_db_instance" "rds_production_replica_2" {
   identifier = "fec-govcloud-prod-replica-2"
   iops = 12000
   maintenance_window = "Sat:06:00-Sat:08:00"
+  parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   apply_immediately = true
 }
 


### PR DESCRIPTION
This changeset swaps the parameter group to the new one we created for parallel query support and improved logging in the production instances.