### PR TITLE
Set postgres `max_standby_streaming_delay` to 1 h

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -105,6 +105,11 @@ resource "aws_db_parameter_group" "fec_default" {
         name  = "log_statement"
         value = "ddl"
     }
+
+    parameter {
+        name  = "max_standby_streaming_delay" # This has no effect on masters, it only affects slaves
+        value = "1 h"
+    }
 }
 
 resource "aws_db_instance" "rds_production" {


### PR DESCRIPTION
This should reduce the incidents of queries on the standby being
canceled with "User query might have needed to see row versions that
must be removed".