### PR TITLE
Add S3 support

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -8,6 +8,10 @@ variable "rds_production_password" {}
 variable "rds_staging_password" {}
 variable "rds_development_password" {}
 
+terraform {
+  backend "s3" {}
+}
+
 provider "aws" {
   region = "${var.region}"
 }


### PR DESCRIPTION
This changeset adds support to pull our info and state from S3 per a recent cloud.gov infrastructure update.