### PR TITLE
increase worker memory

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -114,6 +114,11 @@ resource "aws_db_parameter_group" "fec_default" {
         name  = "max_standby_streaming_delay" # This has no effect on masters, it only affects slaves
         value = "3600000"
     }
+
+    parameter {
+        name  = "work_mem"
+        value = "8"
+    }
 }
 
 resource "aws_db_instance" "rds_production" {

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -112,7 +112,7 @@ resource "aws_db_parameter_group" "fec_default" {
 
     parameter {
         name  = "max_standby_streaming_delay" # This has no effect on masters, it only affects slaves
-        value = "3600000"
+        value = "1200000"
     }
 
     parameter {

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -112,12 +112,12 @@ resource "aws_db_parameter_group" "fec_default" {
 
     parameter {
         name  = "max_standby_streaming_delay" # This has no effect on masters, it only affects slaves
-        value = "1200000"
+        value = "1200000" # in mS
     }
 
     parameter {
         name  = "work_mem"
-        value = "8"
+        value = "8192" # in kB
     }
 }
 


### PR DESCRIPTION
We have been experiencing timeouts and dropped connections between the master and client DBs.

Did some research into better configuration and increasing work memory may help the larger queries that have been failing. Running out of working memory could do that. The memory on the machines overall looks pretty good, so we think the problem is more granular.

research doc here https://docs.google.com/document/d/1zB3CZPaS0gY9vPaIhM5Xn3U-lIMOvsVaip77sIXpJmU/edit# 

The other thing we might want to try is rolling back max_standby_streaming_delay to 20 minutes, instead of an hour (It was originally set to 30s and that caused cancelation errors). That was not the cause of the issue, but it does seem that the error rate went up after that. 

@vrajmohan @ccostino what do you think?