### PR TITLE
Add just the RDS role and policy alone

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -121,6 +121,66 @@ resource "aws_db_parameter_group" "fec_default" {
     }
 }
 
+/* RDS Logging Role */
+resource "aws_iam_role" "rds_logs_role" {
+  name = "rds_logs_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "monitoring.rds.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+/* RDS Logging Policy */
+resource "aws_iam_role_policy" "rds_logs_policy" {
+  depends_on = ["aws_iam_role.rds_logs_role"]
+  name = "rds_logs_policy"
+  role = "${aws_iam_role.rds_logs_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogGroups",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:PutRetentionPolicy"
+      ],
+      "Resource": [
+        "arn:aws-us-gov:logs:*:*:log-group:RDS*"
+      ]
+    },
+    {
+      "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogStreams",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams",
+        "logs:GetLogEvents"
+      ],
+      "Resource": [
+        "arn:aws-us-gov:logs:*:*:log-group:RDS*:log-stream:*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_db_instance" "rds_production" {
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
This changeset adds just the role and policy for enhanced RDS logging - we need these to be in first before associating them with the RDS instances.