### PR TITLE
increase DEV DB size to 2200GB

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -297,7 +297,7 @@ resource "aws_db_instance" "rds_development" {
   engine = "postgres"
   engine_version = "9.6.1"
   instance_class = "db.r3.2xlarge"
-  allocated_storage = 2000
+  allocated_storage = 2200
   name = "fec"
   username = "fec"
   password = "${var.rds_development_password}"


### PR DESCRIPTION
Addresses issue #51 

We are adding a couple hundred more gigabytes to each instance (starting with `dev`).