### PR TITLE
increase database size to 2200GB for STG and PRD

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -203,7 +203,7 @@ resource "aws_db_instance" "rds_production" {
   engine = "postgres"
   engine_version = "9.6.1"
   instance_class = "db.r3.2xlarge"
-  allocated_storage = 2000
+  allocated_storage = 2200
   name = "fec"
   username = "fec"
   password = "${var.rds_production_password}"
@@ -216,7 +216,7 @@ resource "aws_db_instance" "rds_production" {
   auto_minor_version_upgrade = true
   storage_type = "io1"
   identifier = "fec-govcloud-prod"
-  iops = 13000
+  iops = 14000
   maintenance_window = "Sat:06:00-Sat:08:00"
   parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   monitoring_role_arn = "${aws_iam_role.rds_logs_role.arn}"
@@ -235,7 +235,7 @@ resource "aws_db_instance" "rds_production_replica_1" {
   auto_minor_version_upgrade = true
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-1"
-  iops = 13000
+  iops = 14000
   maintenance_window = "Sat:06:00-Sat:08:00"
   parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   monitoring_role_arn = "${aws_iam_role.rds_logs_role.arn}"
@@ -254,7 +254,7 @@ resource "aws_db_instance" "rds_production_replica_2" {
   auto_minor_version_upgrade = true
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-2"
-  iops = 13000
+  iops = 14000
   maintenance_window = "Sat:06:00-Sat:08:00"
   parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   monitoring_role_arn = "${aws_iam_role.rds_logs_role.arn}"
@@ -270,7 +270,7 @@ resource "aws_db_instance" "rds_staging" {
   engine = "postgres"
   engine_version = "9.6.1"
   instance_class = "db.r3.2xlarge"
-  allocated_storage = 2000
+  allocated_storage = 2200
   name = "fec"
   username = "fec"
   password = "${var.rds_staging_password}"

--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -230,6 +230,7 @@ resource "aws_db_instance" "rds_production_replica_1" {
   }
   replicate_source_db = "${aws_db_instance.rds_production.identifier}"
   instance_class = "db.r3.2xlarge"
+  allocated_storage = 2200
   publicly_accessible = true
   storage_encrypted = true
   auto_minor_version_upgrade = true
@@ -249,6 +250,7 @@ resource "aws_db_instance" "rds_production_replica_2" {
   }
   replicate_source_db = "${aws_db_instance.rds_production.identifier}"
   instance_class = "db.r3.2xlarge"
+  allocated_storage = 2200
   publicly_accessible = true
   storage_encrypted = true
   auto_minor_version_upgrade = true
@@ -319,6 +321,7 @@ resource "aws_db_instance" "rds_development" {
 resource "aws_db_instance" "rds_development_replica_1" {
   replicate_source_db = "${aws_db_instance.rds_development.identifier}"
   instance_class = "db.r3.2xlarge"
+  allocated_storage = 2200
   publicly_accessible = true
   storage_encrypted = true
   storage_type = "gp2"


### PR DESCRIPTION
Increase DB size for STG and PRD database in cloud from 2000GB to 2200GB.  Also increase IOPS for PRD and its two replicas from 13000 to 14000 to keep the ratio of IOPS:Storage to similar level.