### PR TITLE
Creating prod-replica-2 back again using terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Terraform configuration and CircleCI for managing custom FEC infrastructure in AWS.
 
 ## Setup
-* CircleCI is configured to deploy the master branch
-* Terraform configuration is deployed via CircleCI to the FEC's AWS account
+* CircleCI is configured to deploy the master branch.
+* Terraform configuration is deployed via CircleCI to the FEC's AWS account.
 
 ## Workflow
 * FEC team member sends a pull request to fecgov/fec-infrastructure


### PR DESCRIPTION
Re-creating prod-replica-2 using terraform 
After successful creation we will delete prod-replica-3 and point all APIs to replica-1 and replica-2 
