### PR TITLE
Change stage-replica-1 from db.r3.2xlarge to db.r3.4xlarge

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -296,7 +296,7 @@ resource "aws_db_instance" "rds_staging_replica_1" {
     prevent_destroy = true
   }
   replicate_source_db = "${aws_db_instance.rds_staging.identifier}"
-  instance_class = "db.r3.2xlarge"
+  instance_class = "db.r3.4xlarge"
   allocated_storage = 2200
   publicly_accessible = true
   storage_encrypted = true


### PR DESCRIPTION
Change DB instance class of stage-replica-1 from db.r3.2xlarge to db.r3.4xlarge
[https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html)

Instance Class | vCPU1 | ECU2 | Memory3 (GiB) | VPC Only4 | EBS Optimized5 | Max. Bandwidth6 (Mbps) | Network Performance7 | MariaDB | Microsoft SQL Server8 | MySQL | Oracle9 | PostgreSQL10
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
db.r3.4xlarge | 16 | 52 | 122 | No | Yes | 2,000 | High | Yes | Yes8 | Yes | Yes9 | Yes
db.r3.2xlarge | 8 | 26 | 61 | No | Yes | 1,000 | High | Yes | Yes8 | Yes | Yes9 | Yes
 



