### PR TITLE
Changed prod-rep2 server class from db.r3.2xlarge to db.r4.8xlarge

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -249,14 +249,14 @@ resource "aws_db_instance" "rds_production_replica_2" {
     prevent_destroy = true
   }
   replicate_source_db = "${aws_db_instance.rds_production.identifier}"
-  instance_class = "db.r3.2xlarge"
+  instance_class = "db.r4.8xlarge"
   allocated_storage = 2200
   publicly_accessible = true
   storage_encrypted = true
   auto_minor_version_upgrade = true
   storage_type = "io1"
   identifier = "fec-govcloud-prod-replica-2"
-  iops = 14000
+  iops = 20000
   maintenance_window = "Sat:06:00-Sat:08:00"
   parameter_group_name = "${aws_db_parameter_group.fec_default.id}"
   monitoring_role_arn = "${aws_iam_role.rds_logs_role.arn}"


### PR DESCRIPTION
Upgrade production RDS replica-2 to satisfy increased demand
Changed server class from db.r3.2xlarge to db.r4.8xlarge
Increased iops from 14000 to 20000