### PR TITLE
Increase storage of prod-replica-1 size to 2.5TB

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -230,7 +230,7 @@ resource "aws_db_instance" "rds_production_replica_1" {
   }
   replicate_source_db = "${aws_db_instance.rds_production.identifier}"
   instance_class = "db.r4.8xlarge"
-  allocated_storage = 2200
+  allocated_storage = 2500
   publicly_accessible = true
   storage_encrypted = true
   auto_minor_version_upgrade = true


### PR DESCRIPTION
Increase storage due to running out of available free space.

![image](https://user-images.githubusercontent.com/20324717/56779475-2df9f280-67a9-11e9-8b71-d4a6e1150151.png)

ERROR: could not write to hash-join temporary file: No space left on device
