### PR TITLE
Increase storage size of all production servers to be 3.5TB

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -203,7 +203,7 @@ resource "aws_db_instance" "rds_production" {
   engine = "postgres"
   engine_version = "9.6.1"
   instance_class = "db.r3.2xlarge"
-  allocated_storage = 2200
+  allocated_storage = 3500
   name = "fec"
   username = "fec"
   password = "${var.rds_production_password}"
@@ -230,7 +230,7 @@ resource "aws_db_instance" "rds_production_replica_1" {
   }
   replicate_source_db = "${aws_db_instance.rds_production.identifier}"
   instance_class = "db.r4.8xlarge"
-  allocated_storage = 2500
+  allocated_storage = 3500
   publicly_accessible = true
   storage_encrypted = true
   auto_minor_version_upgrade = true
@@ -250,7 +250,7 @@ resource "aws_db_instance" "rds_production_replica_2" {
   }
   replicate_source_db = "${aws_db_instance.rds_production.identifier}"
   instance_class = "db.r4.8xlarge"
-  allocated_storage = 2500
+  allocated_storage = 3500
   publicly_accessible = true
   storage_encrypted = true
   auto_minor_version_upgrade = true


### PR DESCRIPTION
Increase AWS RDS prod database storage limit to 3.5 TB due addition of org_type and cmte_dsgn fields and creation of new indexes.  

And also 25million records of ActBlue records expected to be receive by next couple of weeks.

Servers effected:
fec-govcloud-prod
fec-govcloud-prod-replica-1
fec-govcloud-prod-replica-2
