### PR TITLE
Modify storage size of dev, dev-rep-1, stage, stage-rep-1 size to be …

### DIFF
--- a/terraform/fec_rds.tf
+++ b/terraform/fec_rds.tf
@@ -272,7 +272,7 @@ resource "aws_db_instance" "rds_staging" {
   engine = "postgres"
   engine_version = "9.6.1"
   instance_class = "db.r3.2xlarge"
-  allocated_storage = 2200
+  allocated_storage = 3500
   name = "fec"
   username = "fec"
   password = "${var.rds_staging_password}"
@@ -297,7 +297,7 @@ resource "aws_db_instance" "rds_staging_replica_1" {
   }
   replicate_source_db = "${aws_db_instance.rds_staging.identifier}"
   instance_class = "db.r4.8xlarge"
-  allocated_storage = 2200
+  allocated_storage = 3500
   publicly_accessible = true
   storage_encrypted = true
   auto_minor_version_upgrade = true
@@ -319,7 +319,7 @@ resource "aws_db_instance" "rds_development" {
   engine = "postgres"
   engine_version = "9.6.1"
   instance_class = "db.r3.2xlarge"
-  allocated_storage = 2200
+  allocated_storage = 3500
   name = "fec"
   username = "fec"
   password = "${var.rds_development_password}"
@@ -341,7 +341,7 @@ resource "aws_db_instance" "rds_development" {
 resource "aws_db_instance" "rds_development_replica_1" {
   replicate_source_db = "${aws_db_instance.rds_development.identifier}"
   instance_class = "db.r3.2xlarge"
-  allocated_storage = 2200
+  allocated_storage = 3500
   publicly_accessible = true
   storage_encrypted = true
   storage_type = "gp2"


### PR DESCRIPTION
Increase AWS RDS prod database storage limit to 3.5 TB due addition of org_type and cmte_dsgn fields and creation of new indexes.

And also 25million records of ActBlue records expected to be receive by next couple of weeks.

Servers effected:
fec-govcloud-dev
fec-govcloud-dev-replica-1
fec-govcloud-stage
fec-govcloud-stage-replica-1